### PR TITLE
For Docker, convert config object literal to file

### DIFF
--- a/core/util/runDocker.js
+++ b/core/util/runDocker.js
@@ -1,9 +1,10 @@
 const { spawn } = require('child_process');
 const version = require('../../package').version;
+const fs = require('./fs');
 
 module.exports.shouldRunDocker = (config) => config.args.docker;
 
-module.exports.runDocker = (config, backstopCommand) => {
+module.exports.runDocker = async (config, backstopCommand) => {
   if (config.args.docker) {
     // 0th element is node, 1st is backstop, 2nd may be command or an option like --config
     const args = process.argv.slice(2);
@@ -13,11 +14,18 @@ module.exports.runDocker = (config, backstopCommand) => {
       .join('" "') // in case of spaces in a command
       .replace(/--docker/, '--moby');
 
+    const tmpConfigFile = 'backstop.json.tmp';
     // When calling BackstopJS from node config props will be overridden by the passed config object. e.g. backstop('test', {thisProp:'will be passed to config.args'})
     // NOTE: passing config file name is supported -- passing actual config data is not supported.
     let configArgs = '';
     if (config.args && !config.args._) {
       for (var prop in config.args) {
+        if (prop === 'config' && typeof config.args[prop] === 'object') {
+          // If config is an object literal, export it to a json file
+          await fs.writeFile(tmpConfigFile, JSON.stringify(config.args[prop]));
+          config.args[prop] = tmpConfigFile;
+        }
+        
         configArgs += ` "--${prop}=${config.args[prop]}"`;
       }
       configArgs = configArgs.replace(/--docker/, '--moby');
@@ -29,7 +37,11 @@ module.exports.runDocker = (config, backstopCommand) => {
     return new Promise((resolve, reject) => {
       const dockerProcess = spawn(DOCKER_COMMAND, { stdio: 'inherit', shell: true });
       dockerProcess.on('error', err => reject(err));
-      dockerProcess.on('exit', function (code, signal) {
+      dockerProcess.on('exit', async function (code, signal) {
+        if (!config.args.debug && config.args.config === tmpConfigFile) {
+          await fs.unlink(tmpConfigFile);
+        } 
+        
         if (code === 0) {
           resolve();
         } else {


### PR DESCRIPTION
Solves #987. 

It's not possible to pass an object literal via command line to Docker. A config is passed like this: `--config=path-to-config.json`. So the Docker runner assumes that we're using a config file. Currently an object literal evaluated to `--config=[object Object]`. 

This is fixed by saving the object as a JSON file (`backstop.config-for-docker.json`) and letting the `config` option point to that file. When the Docker process `exit`s the file is removed, *unless* the `debug: true` option is passed. Not sure if the debugging thing is actually a good idea. 

Does the Docker process always send an `exit` event, even when there is an `error`? If not, the temporary file should also be removed when there is an error. 